### PR TITLE
Change the number of cores for Nutanix machines

### DIFF
--- a/pkg/asset/machines/master.go
+++ b/pkg/asset/machines/master.go
@@ -454,7 +454,6 @@ func (m *Master) Generate(dependencies asset.Parents) error {
 	case nutanixtypes.Name:
 		mpool := defaultNutanixMachinePoolPlatform()
 		mpool.NumCPUs = 4
-		mpool.NumCoresPerSocket = 4
 		mpool.MemoryMiB = 16384
 		mpool.Set(ic.Platform.Nutanix.DefaultMachinePlatform)
 		mpool.Set(pool.Platform.Nutanix)

--- a/pkg/asset/machines/worker.go
+++ b/pkg/asset/machines/worker.go
@@ -177,7 +177,7 @@ func defaultPowerVSMachinePoolPlatform() powervstypes.MachinePool {
 func defaultNutanixMachinePoolPlatform() nutanixtypes.MachinePool {
 	return nutanixtypes.MachinePool{
 		NumCPUs:           2,
-		NumCoresPerSocket: 2,
+		NumCoresPerSocket: 1,
 		MemoryMiB:         8192,
 		OSDisk: nutanixtypes.OSDisk{
 			DiskSizeMiB: decimalRootVolumeSize * 1024,


### PR DESCRIPTION
Reduce the number of cores per socket in Nutanix machines:
 - Control plane nodes: From 4 cores to 1
 - Worker nodes: From 2 cores to 1

These numbers are based on RedHat guidance.